### PR TITLE
Make mutt launch silenty, and documentation fixes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -120,7 +120,7 @@ If the current spellang is the last allowed, it will disable spell, hit
 once more and you will restart with the first lang.
 You can set the list of allowed langs in your vimrc:
 
-    let g:VimSpellLangs=['fr', 'en', 'sp']
+    let g:VimMailSpellLangs=['fr', 'en', 'sp']
 
 The default langs are french, english.
 
@@ -250,7 +250,7 @@ can disable this feature:
 
 Setting the list of possible spell langs:
 
-    let g:VimSpellLangs=['fr', 'en', 'sp']
+    let g:VimMailSpellLangs=['fr', 'en', 'sp']
 
 ### Folds
 

--- a/doc/vim-mail.txt
+++ b/doc/vim-mail.txt
@@ -99,7 +99,7 @@ If the current spellang is the last allowed, it will disable spell, hit
 once more and you will restart with the first lang.
 You can set the list of allowed langs in your vimrc:
 >
-    let g:VimSpellLangs=['fr', 'en', 'sp']
+    let g:VimMailSpellLangs=['fr', 'en', 'sp']
 <
 The default langs are french, english
 This will work for any filetype as it can be usefull for many other kind of
@@ -227,7 +227,7 @@ Spell                                           *VimMail-spell-configuration*~
 
 Setting the list of possible spell langs:
 >
-    let g:VimSpellLangs=['fr', 'en', 'sp']
+    let g:VimMailSpellLangs=['fr', 'en', 'sp']
 <
 Folds                                           *VimMail-folds-configuration*~
 

--- a/ftplugin/mail.vim
+++ b/ftplugin/mail.vim
@@ -153,7 +153,7 @@ function! VimMailStartClientRO()
     if (!exists("g:VimMailClient"))
         let g:VimMailClient="xterm -e  'mutt -R'"
     endif
-    execute ":! ".g:VimMailClient
+    execute ":silent !".g:VimMailClient
 endfunction
 
 " Fold Method {{{2


### PR DESCRIPTION
Two minor fixes:

1) VimMailStartClientRO now uses :silent ! instead of : ! so that no output is printed to the shell from which the function is called.

2) The documentation now uses the correct variable VimMailSpellLangs instead of VimSpellLangs.
